### PR TITLE
chore: 🤖 remove faker.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
     "ethers": "^5.6.2",
-    "faker": "^6.6.6",
     "git-cz": "^4.8.0",
     "hardhat": "^2.9.2",
     "hardhat-deploy": "^0.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3799,7 +3799,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
-faker@*, faker@^6.6.6:
+faker@*:
   version "6.6.6"
   resolved "https://registry.yarnpkg.com/faker/-/faker-6.6.6.tgz#e9529da0109dca4c7c5dbfeaadbd9234af943033"
   integrity sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==


### PR DESCRIPTION
Package not used, and removing allows to close security risk [CVE-2021-23567](https://github.com/advisories/GHSA-gh88-3pxp-6fm8).