### PR TITLE
feat: etherscan verify

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,10 +6,16 @@ ETH_NODE_URI_GNOSIS=https://rpc.gnosischain.com
 ETH_NODE_URI=https://{{networkName}}.infura.io/v3/<apiKey>
 
 # network specific mnemonic : `"MNEMONIC_ " + networkName.toUpperCase()`
-MNEMONIC_MAINNET=<mnemonic for mainnet>
+# MNEMONIC_MAINNET=<mnemonic for mainnet>
 # generic mnemonic (if no specific found):
 MNEMONIC=<mnemonic>
+
+# forking
+# HARDHAT_FORK=mainnet
 
 # coinmarketcap api key for gas report
 COINMARKETCAP_API_KEY=
 REPORT_GAS=true
+
+# Etherscan API key for automatic verification of contracts
+ETHERSCAN_API_KEY=

--- a/README.md
+++ b/README.md
@@ -54,3 +54,31 @@ This repository uses `hardhat-deploy` for reproducible deployment tests, as well
 
 Deployment scripts are contained within `deploy`, and these deployment scripts are executed
 prior to any tests, and are executed in **alphabetical order**.
+
+### How to use
+
+Unit testing:
+
+```
+yarn test
+```
+
+Coverage analysis:
+
+```
+yarn hardhat coverage
+```
+
+Run deploy scripts and deploy to `mainnet`:
+
+```
+yarn hardhat deploy --network mainnet
+```
+
+Now verify the contracts on Etherscan:
+
+```
+yarn hardhat --network mainnet etherscan-verify
+```
+
+**NOTE: Substitute `mainnet` above for the applicable target network.**

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -115,6 +115,11 @@ const config: HardhatUserConfig = {
   },
   mocha: {
     timeout: 0
+  },
+  verify: {
+    etherscan: {
+      apiKey: process.env.ETHERSCAN_API_KEY
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds automatic verification on Etherscan using `hardhat-deploy`. The API key for Etherscan is configured via environment variable in the applicable `dotenv` configuration.